### PR TITLE
Fixing minor mouse bugs

### DIFF
--- a/Resources/Menus/MinigamesMenu/.gitattributes
+++ b/Resources/Menus/MinigamesMenu/.gitattributes
@@ -1,0 +1,1 @@
+*.{png,psd} filter=lfs diff=lfs merge=lfs -text

--- a/Resources/Menus/MinigamesMenu/Hexus/.gitattributes
+++ b/Resources/Menus/MinigamesMenu/Hexus/.gitattributes
@@ -1,0 +1,1 @@
+*.{png,psd} filter=lfs diff=lfs merge=lfs -text

--- a/Source/Engine/Input/MouseState.cpp
+++ b/Source/Engine/Input/MouseState.cpp
@@ -25,6 +25,11 @@ MouseState::~MouseState()
 {
 }
 
+MouseEvents::MouseEventArgs MouseState::getMouseState()
+{
+	return MouseEvents::MouseEventArgs(MouseState::mousePosition, MouseState::isDragging, MouseState::canClick, MouseState::isLeftClicked);
+}
+
 Vec2 MouseState::getMousePosition()
 {
 	return MouseState::mousePosition;
@@ -72,8 +77,8 @@ void MouseState::onMouseDown(EventMouse* event)
 	MouseState::mousePosition = Vec2(event->getCursorX(), event->getCursorY());
 	MouseState::isLeftClicked = (event->getMouseButton() == EventMouse::MouseButton::BUTTON_LEFT);
 
-	MouseEvents::TriggerMouseDown(this->buildArgs());
-	MouseEvents::TriggerStateChange(this->buildArgs());
+	MouseEvents::TriggerMouseDown(MouseState::getMouseState());
+	MouseEvents::TriggerStateChange(MouseState::getMouseState());
 }
 
 void MouseState::onMouseUp(EventMouse* event)
@@ -81,11 +86,13 @@ void MouseState::onMouseUp(EventMouse* event)
 	MouseState::mousePosition = Vec2(event->getCursorX(), event->getCursorY());
 	MouseState::isLeftClicked = (event->getMouseButton() == EventMouse::MouseButton::BUTTON_LEFT);
 
-	MouseEvents::TriggerMouseUp(this->buildArgs());
+	MouseEvents::TriggerMouseUp(MouseState::getMouseState());
 
 	MouseState::isDragging = false;
+	MouseState::canClick = false;
 
-	MouseEvents::TriggerStateChange(this->buildArgs());
+	MouseEvents::TriggerStateChange(MouseState::getMouseState());
+	MouseEvents::TriggerMouseMove(MouseState::getMouseState());
 }
 
 void MouseState::onMouseMove(EventMouse* event)
@@ -94,37 +101,32 @@ void MouseState::onMouseMove(EventMouse* event)
 	MouseState::isLeftClicked = (event->getMouseButton() == EventMouse::MouseButton::BUTTON_LEFT);
 	MouseState::canClick = false;
 
-	MouseEvents::TriggerMouseMove(this->buildArgs());
-	MouseEvents::TriggerStateChange(this->buildArgs());
+	MouseEvents::TriggerMouseMove(MouseState::getMouseState());
+	MouseEvents::TriggerStateChange(MouseState::getMouseState());
 }
 
 void MouseState::onMouseScroll()
 {
-	MouseEvents::TriggerMouseMove(this->buildArgs());
+	MouseEvents::TriggerMouseMove(MouseState::getMouseState());
 }
 
 void MouseState::onClickableMouseOverEvent(EventCustom* eventCustom)
 {
 	MouseState::canClick = true;
 
-	MouseEvents::TriggerStateChange(this->buildArgs());
+	MouseEvents::TriggerStateChange(MouseState::getMouseState());
 }
 
 void MouseState::onClickableMouseOutEvent(EventCustom* eventCustom)
 {
 	MouseState::canClick = false;
 
-	MouseEvents::TriggerStateChange(this->buildArgs());
+	MouseEvents::TriggerStateChange(MouseState::getMouseState());
 }
 
 void MouseState::onMouseDragEvent(EventCustom* eventCustom)
 {
 	MouseState::isDragging = true;
 
-	MouseEvents::TriggerStateChange(this->buildArgs());
-}
-
-MouseEvents::MouseEventArgs MouseState::buildArgs()
-{
-	return MouseEvents::MouseEventArgs(MouseState::mousePosition, MouseState::isDragging, MouseState::canClick, MouseState::isLeftClicked);
+	MouseEvents::TriggerStateChange(MouseState::getMouseState());
 }

--- a/Source/Engine/Input/MouseState.h
+++ b/Source/Engine/Input/MouseState.h
@@ -14,6 +14,7 @@ public:
 	static void registerGlobalNode();
 
 	static Vec2 getMousePosition();
+	static MouseEvents::MouseEventArgs getMouseState();
 
 private:
 	MouseState();
@@ -27,7 +28,6 @@ private:
 	void onClickableMouseOverEvent(EventCustom* eventCustom);
 	void onClickableMouseOutEvent(EventCustom* eventCustom);
 	void onMouseDragEvent(EventCustom* eventCustom);
-	MouseEvents::MouseEventArgs buildArgs();
 
 	static Vec2 mousePosition;
 	static bool canClick;

--- a/Source/Engine/UI/Controls/MenuSprite.cpp
+++ b/Source/Engine/UI/Controls/MenuSprite.cpp
@@ -56,7 +56,7 @@ MenuSprite::~MenuSprite()
 
 void MenuSprite::onEnter()
 {
-	Node::onEnter();
+	SmartNode::onEnter();
 
 	this->isClickInit = false;
 	this->isClicked = false;
@@ -66,13 +66,21 @@ void MenuSprite::onEnter()
 	this->spriteClicked->setVisible(false);
 	this->spriteSelected->setVisible(false);
 
-	this->initializeListeners();
 	this->scheduleUpdate();
+}
+
+void MenuSprite::onEnterTransitionDidFinish()
+{
+	SmartNode::onEnterTransitionDidFinish();
+
+	// Trigger mouse move event to refresh cursor state
+	MouseEvents::MouseEventArgs args = MouseState::getMouseState();
+	this->mouseMove(&args);
 }
 
 void MenuSprite::update(float dt)
 {
-	Node::update(dt);
+	SmartNode::update(dt);
 
 	// Update the hover/click sprites to track the main sprite
 	this->spriteClicked->setPosition(this->sprite->getPosition());
@@ -133,7 +141,7 @@ void MenuSprite::setClickSound(std::string soundResource)
 
 void MenuSprite::initializeListeners()
 {
-	this->getEventDispatcher()->removeEventListenersForTarget(this);
+	SmartNode::initializeListeners();
 
 	EventListenerCustom* mouseMoveListener = EventListenerCustom::create(MouseEvents::MouseMoveEvent, CC_CALLBACK_1(MenuSprite::onMouseMove, this));
 	EventListenerCustom* mouseDownListener = EventListenerCustom::create(MouseEvents::MouseDownEvent, CC_CALLBACK_1(MenuSprite::onMouseDown, this));
@@ -175,7 +183,21 @@ void MenuSprite::showSprite(Node* sprite)
 
 void MenuSprite::onMouseMove(EventCustom* event)
 {
-	MouseEvents::MouseEventArgs* args = static_cast<MouseEvents::MouseEventArgs*>(event->getUserData());
+	this->mouseMove(static_cast<MouseEvents::MouseEventArgs*>(event->getUserData()), event);
+}
+
+void MenuSprite::onMouseDown(EventCustom* event)
+{
+	this->mouseDown(static_cast<MouseEvents::MouseEventArgs*>(event->getUserData()), event);
+}
+
+void MenuSprite::onMouseUp(EventCustom* event)
+{
+	this->mouseUp(static_cast<MouseEvents::MouseEventArgs*>(event->getUserData()), event);
+}
+
+void MenuSprite::mouseMove(MouseEvents::MouseEventArgs* args, EventCustom* event)
+{
 
 	if (!this->interactionEnabled)
 	{
@@ -235,10 +257,8 @@ void MenuSprite::onMouseMove(EventCustom* event)
 	}
 }
 
-void MenuSprite::onMouseDown(EventCustom* event)
+void MenuSprite::mouseDown(MouseEvents::MouseEventArgs* args, EventCustom* event)
 {
-	MouseEvents::MouseEventArgs* args = static_cast<MouseEvents::MouseEventArgs*>(event->getUserData());
-
 	if (!this->interactionEnabled)
 	{
 		return;
@@ -270,10 +290,8 @@ void MenuSprite::onMouseDown(EventCustom* event)
 	}
 }
 
-void MenuSprite::onMouseUp(EventCustom* event)
+void MenuSprite::mouseUp(MouseEvents::MouseEventArgs* args, EventCustom* event)
 {
-	MouseEvents::MouseEventArgs* args = static_cast<MouseEvents::MouseEventArgs*>(event->getUserData());
-
 	if (!this->interactionEnabled)
 	{
 		return;
@@ -296,14 +314,14 @@ void MenuSprite::onMouseUp(EventCustom* event)
 
 				this->showSprite(this->spriteSelected);
 
-				event->stopPropagation();
+				if (event != nullptr)
+				{
+					event->stopPropagation();
+				}
 			}
 		}
-
-		if (args->isLeftClicked)
-		{
-			this->isClickInit = false;
-			this->isClicked = false;
-		}
 	}
+
+	this->isClickInit = false;
+	this->isClicked = false;
 }

--- a/Source/Engine/UI/Controls/MenuSprite.h
+++ b/Source/Engine/UI/Controls/MenuSprite.h
@@ -3,13 +3,14 @@
 #include "cocos2d.h"
 
 #include "Engine/Events/MouseEvents.h"
+#include "Engine/SmartNode.h"
 #include "Engine/Sound/SoundManager.h"
 #include "Engine/Utils/GameUtils.h"
 #include "Resources.h"
 
 using namespace cocos2d;
 
-class MenuSprite : public Node
+class MenuSprite : public SmartNode
 {
 public:
 	static MenuSprite * create(std::string spriteNormal, std::string spriteSelectedResource, std::string spriteClickedResource);
@@ -31,14 +32,18 @@ protected:
 	~MenuSprite();
 
 private:
-	void initializeListeners();
+	void initializeListeners() override;
 	void onEnter() override;
+	void onEnterTransitionDidFinish() override;
 	void update(float) override;
 	bool intersects(Vec2 mousePos);
 	void showSprite(Node* sprite);
 	void onMouseMove(EventCustom* event);
 	void onMouseDown(EventCustom* event);
 	void onMouseUp(EventCustom* event);
+	void mouseMove(MouseEvents::MouseEventArgs* args, EventCustom* event = nullptr);
+	void mouseDown(MouseEvents::MouseEventArgs* args, EventCustom* event = nullptr);
+	void mouseUp(MouseEvents::MouseEventArgs* args, EventCustom* event = nullptr);
 
 	std::string mouseOverSound;
 	std::string clickSound;


### PR DESCRIPTION
The mouse should now show the right sprite after a scene transition. A few bugs would cause the wrong sprite to be shown.